### PR TITLE
Fix goreleaser dir

### DIFF
--- a/.goreleaser.prerelease.yml
+++ b/.goreleaser.prerelease.yml
@@ -25,4 +25,5 @@ builds:
       - -s
       - -w
       - -X github.com/pulumi/pulumi-str/str/version.Version={{.Tag}}
-    main: ./str/cmd/pulumi-resource-str/
+    main: ./cmd/pulumi-resource-str/
+    dir: str

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,4 +21,5 @@ builds:
       - -s
       - -w
       - -X github.com/pulumi/pulumi-str/str/version.Version={{.Tag}}
-    main: ./str/cmd/pulumi-resource-str/
+    main: ./cmd/pulumi-resource-str/
+    dir: str


### PR DESCRIPTION
Add `dir: str` to the goreleaser builds then correct the relative path for `main`.