### PR TITLE
Modernize CI tooling

### DIFF
--- a/.github/workflows/auto-rebase.yml
+++ b/.github/workflows/auto-rebase.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the latest code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0

--- a/.github/workflows/command-dispatch.yml
+++ b/.github/workflows/command-dispatch.yml
@@ -7,7 +7,7 @@ jobs:
   command-dispatch-for-testing:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Run Build
         uses: peter-evans/slash-command-dispatch@v2
         with:
@@ -20,7 +20,7 @@ jobs:
   auto-rebase-command:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Run Build
         uses: peter-evans/slash-command-dispatch@v2
         with:

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -37,11 +37,11 @@ jobs:
     needs: publish
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Unshallow clone for tags
         run: git fetch --prune --unshallow --tags
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.goversion }}
       - name: Install pulumictl
@@ -51,16 +51,16 @@ jobs:
       - name: Install Pulumi CLI
         uses: pulumi/action-install-pulumi-cli@v2.0.0
       - name: Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{matrix.nodeversion}}
           registry-url: ${{env.NPM_REGISTRY_URL}}
       - name: Setup DotNet
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{matrix.dotnetverson}}
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: ${{matrix.pythonversion}}
       - name: Build SDK
@@ -77,7 +77,7 @@ jobs:
       - name: Compress SDK folder
         run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.language  }}-sdk.tar.gz
           path: ${{ github.workspace}}/sdk/${{ matrix.language }}.tar.gz
@@ -105,7 +105,7 @@ jobs:
         dotnetversion:
           - 3.1.301
         goversion:
-          - 1.18.x
+          - 1.23.x
         language:
           - nodejs
           - python

--- a/.github/workflows/stage-lint.yml
+++ b/.github/workflows/stage-lint.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Lint
         # TODO: Enable linting after a cleanup commit.
         # Avoiding in this commit so as to not mix code changes w/ CI changes.
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.5.0
         with:

--- a/.github/workflows/stage-publish.yml
+++ b/.github/workflows/stage-publish.yml
@@ -25,15 +25,15 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
       - name: Unshallow clone for tags
         run: git fetch --prune --unshallow --tags || true
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.18.x
+          go-version: 1.23.x
       - name: Install pulumictl
         if: ${{ inputs.use-pulumictl }}
         uses: jaxxstorm/action-install-gh-release@v1.5.0

--- a/.github/workflows/stage-test.yml
+++ b/.github/workflows/stage-test.yml
@@ -18,11 +18,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.commit-ref }}
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
           stable: ${{ matrix.go-stable }}
@@ -31,5 +31,5 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.18.x]
+        go-version: [1.23.x]
         go-stable: [true]

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,7 +13,6 @@ linters:
     - misspell
     - nakedret
     - paralleltest
-    - revive
     - unconvert
     - unused
   exclusions:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,31 +1,28 @@
+version: "2"
 run:
   timeout: 10m
-  # Enable checking the by default skipped "examples" dirs
-  skip-dirs:
-    - vendor$
-    - third_party$
-    - testdata$
-    - Godeps$
-    - builtin$
-  skip-dirs-use-default: false
 linters:
-  enable-all: false
+  default: none
   enable:
-    - deadcode
     - errcheck
     - goconst
-    - gofmt
-    - revive
-    - gosec
     - govet
+    - gosec
     - ineffassign
     - lll
     - misspell
     - nakedret
-    - structcheck
-    - unconvert
-    - varcheck
     - paralleltest
-  disable:
-    - staticcheck # Disabled due to OOM errors in golangci-lint@v1.18.0
-    - megacheck # Disabled due to OOM errors in golangci-lint@v1.18.0
+    - revive
+    - unconvert
+    - unused
+  exclusions:
+    paths:
+      - vendor$
+      - third_party$
+      - testdata$
+      - Godeps$
+      - builtin$
+formatters:
+  enable:
+    - gofmt

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,9 @@ VERSION := 1.0.0
 build:
 	mkdir -p bin
 	cd str && go build \
-		-o ../bin \
-		-ldflags "-X github.com/pulumi/pulumi-str/str/version.Version=${VERSION}" ./...
+		-o ../bin/pulumi-resource-str \
+		-ldflags "-X github.com/pulumi/pulumi-str/str/version.Version=${VERSION}" \
+		./cmd/pulumi-resource-str
 
 tidy:
 	cd str && go mod tidy


### PR DESCRIPTION
The repo's CI has rotted into multiple distinct failures. These changes address three of them in one go so we can land #26 (and the broader ESC migration).

- Bump go-version from 1.18.x to 1.23.x in `stage-test.yml`, `stage-publish.yml`, and `publish-release.yaml`. The 1.18 toolchain silently produces no output when running `go build -o <dir> ./...` against this module, which makes `make gen_dotnet_sdk` fail to find `bin/pulumi-resource-str`.

- Migrate `.golangci.yml` to the v2 schema. The lint job uses `golangci/golangci-lint:latest`, which is now v2. The v1 config now fails with `unsupported version of the configuration: ""`. The v2 schema folds `deadcode`/`structcheck`/`varcheck` into the `unused` linter and moves `gofmt` to the `formatters` block; `staticcheck` and `megacheck` remain off by virtue of `default: none`.

- Bump deprecated GitHub Actions versions: `actions/checkout@v2/@v3` -> `@v4`, `setup-go@v2` -> `@v5`, `setup-node@v1` -> `@v4`, `setup-dotnet@v1` -> `@v4`, `setup-python@v1` -> `@v5`, `upload-artifact@v2` -> `@v4`.

This unblocks #26.
