### PR TITLE
Note that pulumi-str is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# WARNING!!! Due to usage of this provider we are planing to archive this, please let us know if you are using it and it will cause you an inconvience. 
+# pulumi-str
 
-Cross language string manipulation functions
+> **This provider is deprecated and is no longer maintained.** It will be archived in the near future. If you are actively using it and archival would cause you problems, please [open an issue](https://github.com/pulumi/pulumi-str/issues/new/choose) so we can hear from you.
 
-Note: This provider is in public beta.
+Cross language string manipulation functions.
 
 ## Provided functions
 


### PR DESCRIPTION
The README's existing warning ("planing to archive...let us know if you are using it") is ambiguous about the provider's actual status. These changes replace it with a clear deprecation notice that:

- States plainly that the provider is deprecated and unmaintained.
- Tells users it will be archived in the near future.
- Points them at the issue tracker if they need to flag a dependency on it before that happens.